### PR TITLE
Add gem flags to V8EquippedItem struct

### DIFF
--- a/sharecode/v8.go
+++ b/sharecode/v8.go
@@ -199,7 +199,10 @@ func NewV8PackedUnitRanks(ranks []uint8) V8PackedUnitRank {
 
 // V8EquippedItem - Equipped item struct
 type V8EquippedItem struct {
-	ItemID uint16
+	ItemID          uint16
+	HasOffensiveGem bool
+	HasDefensiveGem bool
+	HasSupportGem   bool
 }
 
 // V8EquippedItem3Bytes - Equipped items use up 24 bits, yet one byte is unused
@@ -216,8 +219,14 @@ func (item *V8EquippedItem3Bytes) ToEquippedItem() (V8EquippedItem, error) {
 		return V8EquippedItem{}, err
 	}
 
+	// Extract gem flags from the 3rd byte (bits 0, 1, 2)
+	gemByte := item[2]
+
 	return V8EquippedItem{
-		ItemID: itemDefIndex,
+		ItemID:          itemDefIndex,
+		HasOffensiveGem: (gemByte & 0x01) != 0,
+		HasDefensiveGem: (gemByte & 0x02) != 0,
+		HasSupportGem:   (gemByte & 0x04) != 0,
 	}, nil
 }
 
@@ -225,5 +234,18 @@ func (item *V8EquippedItem3Bytes) ToEquippedItem() (V8EquippedItem, error) {
 func NewV8EquippedItem3Bytes(item V8EquippedItem) V8EquippedItem3Bytes {
 	i := item.ItemID
 	var h, l uint8 = uint8(i >> 8), uint8(i & 0xff)
-	return V8EquippedItem3Bytes{l, h, 00}
+
+	// Encode gem flags into the 3rd byte (bits 0, 1, 2)
+	var gemByte uint8 = 0
+	if item.HasOffensiveGem {
+		gemByte |= 0x01
+	}
+	if item.HasDefensiveGem {
+		gemByte |= 0x02
+	}
+	if item.HasSupportGem {
+		gemByte |= 0x04
+	}
+
+	return V8EquippedItem3Bytes{l, h, gemByte}
 }

--- a/sharecode/v8_test.go
+++ b/sharecode/v8_test.go
@@ -82,31 +82,43 @@ func TestNewV8PackedUnitRanks(t *testing.T) {
 
 func TestNewV8EquippedItem3Bytes(t *testing.T) {
 	itemTable := []struct {
-		itemID uint16
-		bytes  [3]byte
+		item  V8EquippedItem
+		bytes [3]byte
 	}{
-		{itemID: 10170, bytes: [3]byte{186, 39, 0}},
-		{itemID: 10171, bytes: [3]byte{187, 39, 0}},
-		{itemID: 10201, bytes: [3]byte{217, 39, 0}},
+		{item: V8EquippedItem{ItemID: 10170}, bytes: [3]byte{186, 39, 0}},
+		{item: V8EquippedItem{ItemID: 10171}, bytes: [3]byte{187, 39, 0}},
+		{item: V8EquippedItem{ItemID: 10201}, bytes: [3]byte{217, 39, 0}},
+		// Test gem flags
+		{item: V8EquippedItem{ItemID: 10170, HasOffensiveGem: true}, bytes: [3]byte{186, 39, 0x01}},
+		{item: V8EquippedItem{ItemID: 10170, HasDefensiveGem: true}, bytes: [3]byte{186, 39, 0x02}},
+		{item: V8EquippedItem{ItemID: 10170, HasSupportGem: true}, bytes: [3]byte{186, 39, 0x04}},
+		{item: V8EquippedItem{ItemID: 10170, HasOffensiveGem: true, HasDefensiveGem: true}, bytes: [3]byte{186, 39, 0x03}},
+		{item: V8EquippedItem{ItemID: 10170, HasOffensiveGem: true, HasDefensiveGem: true, HasSupportGem: true}, bytes: [3]byte{186, 39, 0x07}},
 	}
 
 	for _, item := range itemTable {
-		equippedItem3Bytes := NewV8EquippedItem3Bytes(V8EquippedItem{ItemID: item.itemID})
+		equippedItem3Bytes := NewV8EquippedItem3Bytes(item.item)
 
 		if !bytes.Equal(equippedItem3Bytes[:], item.bytes[:]) {
-			t.Errorf("Equipped item bytes incorrectly encoded")
+			t.Errorf("Equipped item bytes incorrectly encoded: got %v, expected %v", equippedItem3Bytes, item.bytes)
 		}
 	}
 }
 
 func TestToEquippedItem(t *testing.T) {
 	itemTable := []struct {
-		itemID uint16
-		bytes  V8EquippedItem3Bytes
+		expected V8EquippedItem
+		bytes    V8EquippedItem3Bytes
 	}{
-		{itemID: 10170, bytes: [3]byte{186, 39, 0}},
-		{itemID: 10171, bytes: [3]byte{187, 39, 0}},
-		{itemID: 10201, bytes: [3]byte{217, 39, 0}},
+		{expected: V8EquippedItem{ItemID: 10170}, bytes: [3]byte{186, 39, 0}},
+		{expected: V8EquippedItem{ItemID: 10171}, bytes: [3]byte{187, 39, 0}},
+		{expected: V8EquippedItem{ItemID: 10201}, bytes: [3]byte{217, 39, 0}},
+		// Test gem flags
+		{expected: V8EquippedItem{ItemID: 10170, HasOffensiveGem: true}, bytes: [3]byte{186, 39, 0x01}},
+		{expected: V8EquippedItem{ItemID: 10170, HasDefensiveGem: true}, bytes: [3]byte{186, 39, 0x02}},
+		{expected: V8EquippedItem{ItemID: 10170, HasSupportGem: true}, bytes: [3]byte{186, 39, 0x04}},
+		{expected: V8EquippedItem{ItemID: 10170, HasOffensiveGem: true, HasDefensiveGem: true}, bytes: [3]byte{186, 39, 0x03}},
+		{expected: V8EquippedItem{ItemID: 10170, HasOffensiveGem: true, HasDefensiveGem: true, HasSupportGem: true}, bytes: [3]byte{186, 39, 0x07}},
 	}
 
 	for _, item := range itemTable {
@@ -114,10 +126,18 @@ func TestToEquippedItem(t *testing.T) {
 		if err != nil {
 			t.Errorf("Error converting bytes to equipped item: %s", err)
 		}
-		equippedItemID := equippedItem.ItemID
 
-		if equippedItemID != item.itemID {
-			t.Errorf("Incorrectly deserialized item id. Got %d instead of %d", equippedItemID, item.itemID)
+		if equippedItem.ItemID != item.expected.ItemID {
+			t.Errorf("Incorrectly deserialized item id. Got %d instead of %d", equippedItem.ItemID, item.expected.ItemID)
+		}
+		if equippedItem.HasOffensiveGem != item.expected.HasOffensiveGem {
+			t.Errorf("Incorrectly deserialized HasOffensiveGem. Got %v instead of %v", equippedItem.HasOffensiveGem, item.expected.HasOffensiveGem)
+		}
+		if equippedItem.HasDefensiveGem != item.expected.HasDefensiveGem {
+			t.Errorf("Incorrectly deserialized HasDefensiveGem. Got %v instead of %v", equippedItem.HasDefensiveGem, item.expected.HasDefensiveGem)
+		}
+		if equippedItem.HasSupportGem != item.expected.HasSupportGem {
+			t.Errorf("Incorrectly deserialized HasSupportGem. Got %v instead of %v", equippedItem.HasSupportGem, item.expected.HasSupportGem)
 		}
 	}
 }


### PR DESCRIPTION
The ShareCodeEquippedItem struct includes three bit flags for gems
(HasOffensiveGem, HasDefensiveGem, HasSupportGem) in the 3rd byte that
were previously not being parsed or encoded in the Go implementation.

- Add HasOffensiveGem, HasDefensiveGem, HasSupportGem bool fields
- Update ToEquippedItem() to extract gem flags from bits 0, 1, 2
- Update NewV8EquippedItem3Bytes() to encode gem flags into 3rd byte
- Add comprehensive test cases for gem flag encoding/decoding